### PR TITLE
GIT-7: Add linter & formater

### DIFF
--- a/docs/lint.md
+++ b/docs/lint.md
@@ -1,0 +1,64 @@
+## Setting Up Custom ESLint Config in PhpStorm
+
+### 1. Install packages
+`pnpm install`
+
+### 2. Check Eslint run result
+`pnpm run lint`
+
+### Linting Rules
+Project uses the custom Eslint config based on the standard Eslint, TS etc. recommended configs.
+
+Lint and Styling rules specified at `eslint.rules.js` file.
+
+## Set Eslint as standard linter/formater in IDE
+
+### PHPStorm/WebStorm
+
+Go to **Settings/Preferences** (`Ctrl+Alt+S` on Windows/Linux, `Cmd+,` on Mac):
+
+- Navigate to: **Languages & Frameworks → JavaScript → Code Quality Tools → ESLint**
+- Select **"Manual ESLint configuration"**:
+  - Set the **ESLint package** path (usually `node_modules/eslint`)
+  - Set the **Working directories** path to the memora-cards project folder
+  - Choose your **Configuration file** in root of project `eslint.config.js`
+- Set **Run for files** - `**/*.{ts,tsx,mts,cts,js}`
+- Check **"Run eslint --fix on save"** to automatically fix issues when you save files
+
+On rule change restart IDE or restart Eslint language server in the left-bottom corner of IDE.
+
+### VSCode
+
+Install ESLint extension from **Microsoft**.
+ 
+Specify at **settings.json**:
+```json
+{
+  "editor.tabSize": 2,
+  "eslint.enable": true,
+  "eslint.useFlatConfig": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.options": {
+    "overrideConfigFile": "./eslint.config.js"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
+}
+```
+
+On rule change restart IDE or restart Eslint language server `ctrl + shift + p` (or `Cmd+Shift+P` on Mac) -> `ESLint: Restart ESLint Server`.
+
+
+## References
+- [Eslint Rules](https://eslint.org/docs/latest/rules/)
+- [TS Rules](https://typescript-eslint.io/rules/)
+- [React Rules](https://react.dev/reference/eslint-plugin-react-hooks)
+- [Fast Refresh Article](https://dev.to/md_belayethossain_56e787/fast-refresh-only-works-when-a-file-only-exports-components-why-does-this-problem-occur-and-how-1b4)
+- [Simple ESLint Setup Guide](https://stack.convex.dev/eslint-setup)
+- [Simple Video Setup Guide](https://www.youtube.com/watch?v=eieTlMwCwWU)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,35 @@
-import js from '@eslint/js'
-import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import stylistic from '@stylistic/eslint-plugin'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import rules from './eslint.rules.js'
+import globals from 'globals'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'node_modules']),
   {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs['recommended-latest'],
-      reactRefresh.configs.vite,
-    ],
+    files: ['**/*.{ts,tsx,js,mts,cts}'],
+    plugins: {
+      '@typescript-eslint': tseslint.configs.recommended[0].plugins['@typescript-eslint'],
+      'react-hooks': reactHooks.configs['recommended-latest'].plugins['react-hooks'],
+      '@stylistic': stylistic.configs['recommended'].plugins['@stylistic'],
+      'react-refresh': reactRefresh.configs.vite.plugins['react-refresh']
+    },
+    rules: {
+      ...rules.ts,
+      ...rules.js,
+      ...rules.reactHooks,
+      ...rules.stylistic,
+      ...reactRefresh.configs.vite.rules
+    },
     languageOptions: {
       ecmaVersion: 2022,
-      globals: globals.browser,
-    },
-  },
+      sourceType: 'module',
+      parser: tseslint.parser,
+      globals: {
+        ...globals.browser
+      }
+    }
+  }
 ])

--- a/eslint.rules.js
+++ b/eslint.rules.js
@@ -1,0 +1,249 @@
+const js = Object.freeze({
+  'constructor-super': 'error',
+  'getter-return': 'error',
+  'for-direction': 'error',
+  'no-async-promise-executor': 'error',
+  'no-case-declarations': 'error',
+  'no-class-assign': 'error',
+  'no-compare-neg-zero': 'error',
+  'no-cond-assign': 'error',
+  'no-const-assign': 'error',
+  'no-constant-binary-expression': 'error',
+  'no-constant-condition': 'error',
+  'no-control-regex': 'error',
+  'no-debugger': 'error',
+  'no-delete-var': 'error',
+  'no-dupe-args': 'error',
+  'no-dupe-class-members': 'error',
+  'no-dupe-else-if': 'error',
+  'no-dupe-keys': 'error',
+  'no-duplicate-case': 'error',
+  'no-empty': 'error',
+  'no-empty-character-class': 'error',
+  'no-empty-pattern': 'error',
+  'no-empty-static-block': 'error',
+  'no-ex-assign': 'error',
+  'no-extra-boolean-cast': 'error',
+  'no-fallthrough': 'error',
+  'no-func-assign': 'error',
+  'no-global-assign': 'error',
+  'no-import-assign': 'error',
+  'no-invalid-regexp': 'error',
+  'no-irregular-whitespace': 'error',
+  'no-loss-of-precision': 'error',
+  'no-misleading-character-class': 'error',
+  'no-new-native-nonconstructor': 'error',
+  'no-nonoctal-decimal-escape': 'error',
+  'no-obj-calls': 'error',
+  'no-octal': 'error',
+  'no-prototype-builtins': 'error',
+  'no-redeclare': 'error',
+  'no-regex-spaces': 'error',
+  'no-self-assign': 'error',
+  'no-setter-return': 'error',
+  'no-shadow-restricted-names': 'error',
+  'no-sparse-arrays': 'error',
+  'no-this-before-super': 'error',
+  'no-undef': 'error',
+  'no-unexpected-multiline': 'error',
+  'no-unreachable': 'error',
+  'no-unsafe-finally': 'error',
+  'no-unsafe-negation': 'error',
+  'no-unsafe-optional-chaining': 'error',
+  'no-unused-labels': 'error',
+  'no-unused-private-class-members': 'error',
+  'no-unused-vars': 'off',
+  'no-useless-backreference': 'error',
+  'no-useless-catch': 'error',
+  'no-useless-escape': 'error',
+  'no-with': 'error',
+  'require-yield': 'error',
+  'use-isnan': 'error',
+  'valid-typeof': 'error',
+  'no-var': 'error',
+  'prefer-const': 'error',
+  'prefer-rest-params': 'error',
+  'prefer-spread': 'error',
+  'no-duplicate-imports': 'error',
+  'no-promise-executor-return': 'error',
+  'no-self-compare': 'error',
+  'no-template-curly-in-string': 'error',
+  'no-unassigned-vars': 'error'
+});
+
+const ts = Object.freeze({
+  '@typescript-eslint/ban-ts-comment': 'error',
+  '@typescript-eslint/no-array-constructor': 'error',
+  '@typescript-eslint/no-duplicate-enum-values': 'error',
+  '@typescript-eslint/no-empty-object-type': 'error',
+  '@typescript-eslint/no-explicit-any': 'error',
+  '@typescript-eslint/no-extra-non-null-assertion': 'error',
+  '@typescript-eslint/no-misused-new': 'error',
+  '@typescript-eslint/no-namespace': 'error',
+  '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+  '@typescript-eslint/no-require-imports': 'error',
+  '@typescript-eslint/no-this-alias': 'error',
+  '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+  '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+  '@typescript-eslint/no-unsafe-function-type': 'error',
+  '@typescript-eslint/no-unused-expressions': 'error',
+  '@typescript-eslint/no-unused-vars': ['error'],
+  '@typescript-eslint/no-wrapper-object-types': 'error',
+  '@typescript-eslint/prefer-as-const': 'error',
+  '@typescript-eslint/prefer-namespace-keyword': 'error',
+  '@typescript-eslint/triple-slash-reference': 'error'
+});
+
+const reactHooks = Object.freeze({
+  'react-hooks/rules-of-hooks': 'error',
+  'react-hooks/exhaustive-deps': 'warn'
+});
+
+const stylistic = Object.freeze(
+  {
+    '@stylistic/array-bracket-spacing': ['error', 'never'],
+    '@stylistic/arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
+    '@stylistic/arrow-spacing': ['error', { after: true, before: true }],
+    '@stylistic/block-spacing': ['error', 'always'],
+    '@stylistic/brace-style': ['error', 'stroustrup', { allowSingleLine: true }],
+    '@stylistic/comma-dangle': ['error', 'never'],
+    '@stylistic/comma-spacing': ['error', { after: true, before: false }],
+    '@stylistic/comma-style': ['error', 'last'],
+    '@stylistic/computed-property-spacing': ['error', 'never', { enforceForClassMembers: true }],
+    '@stylistic/dot-location': ['error', 'property'],
+    '@stylistic/eol-last': 'error',
+    '@stylistic/generator-star-spacing': ['error', { after: true, before: false }],
+    '@stylistic/indent': [
+      'error', 2,
+      {
+        ArrayExpression: 1,
+        CallExpression: { arguments: 1 },
+        flatTernaryExpressions: false,
+        FunctionDeclaration: { body: 1, parameters: 1, returnType: 1 },
+        FunctionExpression: { body: 1, parameters: 1, returnType: 1 },
+        ignoreComments: false,
+        ignoredNodes: ['TSUnionType', 'TSIntersectionType'],
+        ImportDeclaration: 1,
+        MemberExpression: 1,
+        ObjectExpression: 1,
+        offsetTernaryExpressions: true,
+        outerIIFEBody: 1,
+        SwitchCase: 1,
+        tabLength: 2,
+        VariableDeclarator: 1
+      }
+    ],
+    '@stylistic/indent-binary-ops': ['error', 2],
+    '@stylistic/key-spacing': ['error', { afterColon: true, beforeColon: false }],
+    '@stylistic/keyword-spacing': ['error', { after: true, before: true }],
+    '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+    '@stylistic/max-statements-per-line': ['error', { max: 1 }],
+    '@stylistic/member-delimiter-style': [
+      'error',
+      {
+        multiline: { delimiter: 'none', requireLast: false },
+        multilineDetection: 'brackets',
+        overrides: {
+          interface: { multiline: { delimiter: 'none', requireLast: false } }
+        },
+        singleline: { delimiter: 'comma' }
+      }
+    ],
+    '@stylistic/multiline-ternary': ['error', 'always-multiline'],
+    '@stylistic/new-parens': 'error',
+    '@stylistic/no-extra-parens': ['error', 'functions'],
+    '@stylistic/no-floating-decimal': 'error',
+    '@stylistic/no-mixed-operators': [
+      'error',
+      {
+        allowSamePrecedence: true,
+        groups: [
+          [
+            '==', '!=', '===',
+            '!==', '>', '>=',
+            '<', '<='
+          ],
+          ['&&', '||'],
+          ['in', 'instanceof']
+        ]
+      }
+    ],
+    '@stylistic/no-mixed-spaces-and-tabs': 'error',
+    '@stylistic/no-multi-spaces': 'error',
+    '@stylistic/no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
+    '@stylistic/no-tabs': 'error',
+    '@stylistic/no-trailing-spaces': 'error',
+    '@stylistic/no-whitespace-before-property': 'error',
+    '@stylistic/object-curly-spacing': ['error', 'always'],
+    '@stylistic/operator-linebreak': ['error', 'before'],
+    '@stylistic/padded-blocks': ['error', { blocks: 'never', classes: 'never', switches: 'never' }],
+    '@stylistic/quote-props': ['error', 'consistent-as-needed'],
+    '@stylistic/quotes': [
+      'error',
+      'single',
+      { allowTemplateLiterals: 'always', avoidEscape: false }
+    ],
+    '@stylistic/rest-spread-spacing': ['error', 'never'],
+    '@stylistic/semi': ['error', 'always', { omitLastInOneLineClassBody: true }],
+    '@stylistic/semi-spacing': ['error', { after: true, before: false }],
+    '@stylistic/space-before-blocks': ['error', 'always'],
+    '@stylistic/space-before-function-paren': [
+      'error',
+      { anonymous: 'always', asyncArrow: 'always', named: 'never' }
+    ],
+    '@stylistic/space-in-parens': ['error', 'never'],
+    '@stylistic/space-infix-ops': 'error',
+    '@stylistic/space-unary-ops': ['error', { nonwords: false, words: true }],
+    '@stylistic/spaced-comment': [
+      'error',
+      'always',
+      {
+        block: { balanced: true, exceptions: ['*'], markers: ['!'] },
+        line: { exceptions: ['/', '#'], markers: ['/'] }
+      }
+    ],
+    '@stylistic/template-curly-spacing': 'error',
+    '@stylistic/template-tag-spacing': ['error', 'never'],
+    '@stylistic/type-annotation-spacing': ['error', {}],
+    '@stylistic/type-generic-spacing': 'error',
+    '@stylistic/type-named-tuple-spacing': 'error',
+    '@stylistic/wrap-iife': ['error', 'any', { functionPrototypeMethods: true }],
+    '@stylistic/yield-star-spacing': ['error', { after: true, before: false }],
+    '@stylistic/jsx-closing-bracket-location': 'error',
+    '@stylistic/jsx-closing-tag-location': 'error',
+    '@stylistic/jsx-curly-brace-presence': ['error', { propElementValues: 'always' }],
+    '@stylistic/jsx-curly-newline': 'error',
+    '@stylistic/jsx-curly-spacing': ['error', 'never'],
+    '@stylistic/jsx-equals-spacing': 'error',
+    '@stylistic/jsx-first-prop-new-line': 'error',
+    '@stylistic/jsx-function-call-newline': ['error', 'multiline'],
+    '@stylistic/jsx-indent-props': ['error', 2],
+    '@stylistic/jsx-max-props-per-line': ['error', { maximum: 1, when: 'multiline' }],
+    '@stylistic/jsx-one-expression-per-line': ['error', { allow: 'single-child' }],
+    '@stylistic/jsx-quotes': 'error',
+    '@stylistic/jsx-tag-spacing': [
+      'error',
+      {
+        afterOpening: 'never',
+        beforeClosing: 'never',
+        beforeSelfClosing: 'always',
+        closingSlash: 'never'
+      }
+    ],
+    '@stylistic/jsx-wrap-multilines': [
+      'error',
+      {
+        arrow: 'parens-new-line',
+        assignment: 'parens-new-line',
+        condition: 'parens-new-line',
+        declaration: 'parens-new-line',
+        logical: 'parens-new-line',
+        prop: 'parens-new-line',
+        propertyValue: 'parens-new-line',
+        return: 'parens-new-line'
+      }
+    ]
+  }
+);
+
+export default { js, ts, reactHooks, stylistic };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@eslint/js": "~9.36.0",
+    "@stylistic/eslint-plugin": "~5.5.0",
     "@types/node": "~24.8.1",
     "@types/react": "~19.2.0",
     "@types/react-dom": "~19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ~9.36.0
         version: 9.36.0
+      '@stylistic/eslint-plugin':
+        specifier: ~5.5.0
+        version: 5.5.0(eslint@9.36.0)
       '@types/node':
         specifier: ~24.8.1
         version: 24.8.1
@@ -487,6 +490,12 @@ packages:
     resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
     cpu: [x64]
     os: [win32]
+
+  '@stylistic/eslint-plugin@5.5.0':
+    resolution: {integrity: sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1479,6 +1488,16 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
+
+  '@stylistic/eslint-plugin@5.5.0(eslint@9.36.0)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
+      '@typescript-eslint/types': 8.46.1
+      eslint: 9.36.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import type React from "react"
+import type React from 'react';
 
 const App: React.FC = () => {
   return (
     <h1>MEMORA CARDS</h1>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,5 +5,5 @@ import App from './App.tsx'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [],
-      },
-    }),
-  ],
+        plugins: []
+      }
+    })
+  ]
 })


### PR DESCRIPTION
## 📦 What’s inside this PR?

Investigate the recomended ESLint config from default vite project.
Investigate ESLint and plugins docs to understend the recommended rules aplications.
Move all recomended rules to the external `eslint.rules.js` file for more easy editing and configuring lenter/formater.
Update configuration with additinal rules.

---

## 📄 Related Issue

Closes #7  

---

## ✅ Checklist (before submitting)

- [x] The PR targets the `develop` branch
- [x] I've followed the [Git Flow rules](../docs/git-flow.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Linter passes (`pnpm run lint`)
- [x] I've updated documentation if needed

---
### Test
App.tsx test code with lint errors
```
import React, {
  useEffect
} from 'react'

export const testFunc = () => {
  return 1
}

const App: React.FC = () => {
  const a = {}
  const b = [0, 1, 2]

  Object.defineProperty(a, 'age', {
    get: function () {
      // no returns.
    }
  })

  const logItems = () => {
    console.log(a)
  }

  useEffect(() => {
    logItems()
  }, [logItems])

  console.log(b)

  return (
    <h1>MEMORA CARDS</h1>
  )
}

export default App
```
### Lint report

```
   5:14  error    Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components                                                                                    
           react-refresh/only-export-components
  14:5   error    Expected to return a value in method 'get'                                                                                                                                                                        
           getter-return
  19:9   warning  The 'logItems' function makes the dependencies of useEffect Hook (at line 25) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'logItems' in its own useCallback() Hook  react-hooks/exhaustive-deps
```
Supress lint rules form Lint report at `eslitnt.rules.js`. Lint reprorp empty
<img width="717" height="126" alt="image" src="https://github.com/user-attachments/assets/d33ed18b-20dd-431b-967d-a5f9c7954536" />

 Proved that rules form `eslitnt.rules.js` applied.
 
 ## Formating
 Before save
<img width="813" height="311" alt="image" src="https://github.com/user-attachments/assets/da556adb-2921-4299-b4f5-c26e11fd516f" />

After save
<img width="763" height="290" alt="image" src="https://github.com/user-attachments/assets/3c7e6d40-5434-437e-9971-f32394bdc2da" />


## Screenshots

<img width="1214" height="732" alt="image" src="https://github.com/user-attachments/assets/7277cdaf-8f15-46af-8a62-fa9641e26b8e" />
<img width="561" height="390" alt="image" src="https://github.com/user-attachments/assets/c08d9430-76f8-47f1-b28d-690f6cc549b0" />
<img width="792" height="769" alt="image" src="https://github.com/user-attachments/assets/23b250fe-a3ad-410b-801a-39b8438cd5a6" />


## 📝 Additional Notes

Check the **lint.md** there is instructions how to enable ESLint/Formater at PHPStorm/WebStorm and VSCode

## References 
- [Eslint Rules](https://eslint.org/docs/latest/rules/)
- [TS Rules](https://typescript-eslint.io/rules/)
- [React Rules](https://react.dev/reference/eslint-plugin-react-hooks)
- [Fast Refresh Article](https://dev.to/md_belayethossain_56e787/fast-refresh-only-works-when-a-file-only-exports-components-why-does-this-problem-occur-and-how-1b4)
- [Simple ESLint Setup Guide](https://stack.convex.dev/eslint-setup)
- [Simple Video Setup Guid](https://www.youtube.com/watch?v=eieTlMwCwWU)