### PR TITLE
feature: mc#1/add H1 component

### DIFF
--- a/src/pages/Decks/Decks.tsx
+++ b/src/pages/Decks/Decks.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { NavLink } from 'react-router';
+import { H1 } from '../../shared/ui/atoms/H1/H1.tsx';
 
 export const Decks: React.FC = () => {
   return (
     <>
-      <h1>Decks Page</h1>
+      <H1>Decks Page</H1>
       <NavLink to="/">Go to Home</NavLink>
     </>
   );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { NavLink } from 'react-router';
 import { Container } from '../../shared/ui/atoms/Container/Container';
+import {
+  H1
+} from '../../shared/ui/atoms/H1/H1.tsx';
 
 export const Home: React.FC = () => {
   return (
     <>
       <Container>
-        <h1>Home Page</h1>
+        <H1>Home Page</H1>
       </Container>
       <Container fluid>
         <NavLink to="/decks">Go to Decks</NavLink>

--- a/src/shared/ui/atoms/Container/Container.stories.tsx
+++ b/src/shared/ui/atoms/Container/Container.stories.tsx
@@ -2,7 +2,7 @@ import { Container } from './Container.tsx';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta = {
-  title: 'Component/Container',
+  title: 'UI/Atoms/Container',
   component: Container,
   tags: ['autodocs'],
   args: {

--- a/src/shared/ui/atoms/H1/H1.module.css
+++ b/src/shared/ui/atoms/H1/H1.module.css
@@ -1,0 +1,7 @@
+.h1 {
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-size-h-1);
+  font-weight: var(--font-weight-bold);
+  line-height: normal;
+}

--- a/src/shared/ui/atoms/H1/H1.stories.tsx
+++ b/src/shared/ui/atoms/H1/H1.stories.tsx
@@ -1,0 +1,46 @@
+import { H1 } from './H1.tsx';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'UI/Atoms/H1',
+  component: H1,
+  tags: ['autodocs'],
+  args: {
+    children: 'Title'
+  },
+  argTypes: {
+    children: {
+      control: { type: 'text' }
+    }
+  }
+} satisfies Meta<typeof H1>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Title'
+  }
+};
+
+export const RedTitle: Story = {
+  args: {
+    children: 'Red Title',
+    style: { color: 'red' }
+  }
+};
+
+export const WithExtraClasses: Story = {
+  args: {
+    children: 'Title with Extra Classes',
+    className: ['extra-class-1', 'extra-class-2']
+  }
+};
+
+export const CustomTestId: Story = {
+  args: {
+    'children': 'Title with Custom Test ID',
+    'data-testid': 'custom-h1'
+  }
+};

--- a/src/shared/ui/atoms/H1/H1.test.tsx
+++ b/src/shared/ui/atoms/H1/H1.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { H1 } from './H1';
+import styles from './H1.module.css';
+
+describe('H1 component', () => {
+  it('renders children correctly', () => {
+    render(<H1>Test Heading</H1>);
+    const heading = screen.getByTestId('heading');
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe('H1');
+    expect(heading).toHaveTextContent('Test Heading');
+  });
+
+  it('applies base class from CSS module', () => {
+    render(<H1>Heading</H1>);
+    const heading = screen.getByTestId('heading');
+    expect(heading.className).toContain(styles.h1);
+  });
+
+  it('appends additional class names when provided', () => {
+    render(<H1 className={['extra-class', 'another-class']}>Heading</H1>);
+    const heading = screen.getByTestId('heading');
+
+    expect(heading.className).toContain(styles.h1);
+    expect(heading.className).toContain('extra-class');
+    expect(heading.className).toContain('another-class');
+  });
+
+  it('applies inline style when provided', () => {
+    const style: React.CSSProperties = { color: 'red', fontSize: '24px' };
+    render(
+      <H1 style={style}>Styled Heading</H1>
+    );
+    const heading = screen.getByTestId('heading');
+
+    expect(heading.style.color).toBe('red');
+    expect(heading.style.fontSize).toBe('24px');
+  });
+
+  it('uses custom data-testid when provided', () => {
+    render(<H1 data-testid="custom-id">Heading</H1>);
+    const heading = screen.getByTestId('custom-id');
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent('Heading');
+  });
+
+  it('renders ReactNode children (nested elements)', () => {
+    render(
+      <H1>
+        <span data-testid="nested">Nested</span>
+      </H1>
+    );
+    const nested = screen.getByTestId('nested');
+    expect(nested).toBeInTheDocument();
+    expect(nested).toHaveTextContent('Nested');
+  });
+
+  it('handles empty className array gracefully', () => {
+    render(<H1 className={[]}>Heading</H1>);
+    const heading = screen.getByTestId('heading');
+    // Should only have the base CSS module class
+    expect(heading.className).toBe(styles.h1);
+  });
+});

--- a/src/shared/ui/atoms/H1/H1.tsx
+++ b/src/shared/ui/atoms/H1/H1.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from './H1.module.css';
+
+interface H1Props {
+  children: React.ReactNode
+  className?: string[]
+  style?: React.CSSProperties
+  ['data-testid']?: string
+}
+
+export const H1: React.FC<H1Props> = ({ children, className, style, 'data-testid': dataTestId = 'heading' }) => {
+  const cls = [styles.h1];
+  if (className) cls.push(...className);
+  const classes = cls.join(' ');
+
+  return (
+    <h1 style={style} className={classes} data-testid={dataTestId}>{children}</h1>
+  );
+};

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -17,10 +17,6 @@ body {
 
 body {
   -webkit-font-smoothing: antialiased;
-  font-family: Inter, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.5;
 }
 
 img, picture, video, canvas, svg {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -3,7 +3,7 @@
   --color-text: #0f172a;
   --color-link: #0b57d0;
 
-  --font-title-1: 2rem;
+  --font-size-h-1: 2rem;
   --font-title-2: 1.5rem;
   --font-text: 1rem;
 
@@ -16,11 +16,23 @@
   font-optical-sizing: auto;
   font-style: normal;
   font-variation-settings:
-      "wdth" 100;
+    "wdth" 100;
 }
 
 [data-theme="dark"] {
   --color-bg: #101214;
   --color-text: #f5f7fb;
   --color-link: #8ab4f8;
+}
+
+@media (max-width: 1192px) {
+  :root {
+    --font-size-h-1: 1.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --font-size-h-1: 1.5rem;
+  }
 }


### PR DESCRIPTION
## 📦 What’s inside this PR?

- add H1 component
- **supports**: 
  - `style`: React.CSSProperties,
  - `className`: string[], 
  - `children`: string | React.FC | ReactNode


## 📄 Related Issue

Closes [MC-1](https://zloyleva.atlassian.net/jira/software/projects/MC/boards/34?selectedIssue=MC-1)  
---

## ✅ Checklist (before submitting)

- [x] The PR targets the `develop` branch
- [x] I've followed the [Git Flow rules](../docs/git-flow.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code builds and works locally (`pnpm dev`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x]  I've updated documentation if needed


[MC-1]: https://zloyleva.atlassian.net/browse/MC-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ