### PR TITLE
feature: mc#4/add Breadcrumbs component

### DIFF
--- a/eslint.rules.js
+++ b/eslint.rules.js
@@ -118,7 +118,7 @@ const stylistic = Object.freeze(
       {
         ArrayExpression: 1,
         CallExpression: { arguments: 1 },
-        flatTernaryExpressions: false,
+        flatTernaryExpressions: true,
         FunctionDeclaration: { body: 1, parameters: 1, returnType: 1 },
         FunctionExpression: { body: 1, parameters: 1, returnType: 1 },
         ignoreComments: false,
@@ -126,7 +126,7 @@ const stylistic = Object.freeze(
         ImportDeclaration: 1,
         MemberExpression: 1,
         ObjectExpression: 1,
-        offsetTernaryExpressions: true,
+        offsetTernaryExpressions: false,
         outerIIFEBody: 1,
         SwitchCase: 1,
         tabLength: 2,

--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.module.css
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.module.css
@@ -1,0 +1,25 @@
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--breadcrumbs-gap);
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+.breadcrumbs .separator {
+  padding-right: var(--breadcrumbs-gap);
+}
+
+.breadcrumbs.variant--wrap {
+  flex-wrap: wrap;
+}
+
+.breadcrumbs.variant--truncate {
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.breadcrumbs .label {
+  display: inline-flex;
+  white-space: nowrap;
+}

--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,163 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Breadcrumbs } from './Breadcrumbs.tsx';
+
+const meta = {
+  title: 'UI/Atoms/Breadcrumbs',
+  component: Breadcrumbs,
+  tags: ['autodocs'],
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ]
+  },
+  argTypes: {
+    items: {
+      control: { type: 'object' }
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['truncate', 'wrap']
+    },
+    separator: {
+      control: { type: 'text' }
+    }
+  }
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    separator: '/'
+  }
+};
+
+export const TwoItems: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Current Page' }
+    ]
+  }
+};
+
+export const FourItems: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Category', link: '/category' },
+      { label: 'Subcategory', link: '/category/sub' },
+      { label: 'Current Page' }
+    ]
+  }
+};
+
+export const LongBreadcrumb: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Very Long Category Name That Might Overflow', link: '/long-category' },
+      { label: 'Another Extremely Long Subcategory Name Here', link: '/long-category/sub' },
+      { label: 'Current Product Page With Very Long Title That Could Cause Layout Issues' }
+    ]
+  }
+};
+
+export const WithTruncateBehaviour: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Very Long Category Name That Might Overflow', link: '/long-category' },
+      { label: 'Another Extremely Long Subcategory Name Here', link: '/long-category/sub' },
+      { label: 'Current Product Page With Very Long Title That Could Cause Layout Issues' }
+    ],
+    variant: 'truncate'
+  }
+};
+
+export const WithWrapBehaviour: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Very Long Category Name That Might Overflow', link: '/long-category' },
+      { label: 'Another Extremely Long Subcategory Name Here', link: '/long-category/sub' },
+      { label: 'Current Product Page With Very Long Title That Could Cause Layout Issues' }
+    ],
+    variant: 'wrap'
+  }
+};
+
+export const CustomSeparator: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    separator: '>'
+  }
+};
+
+export const CustomSeparatorWithSpaces: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    separator: ' › '
+  }
+};
+
+export const WithExtraClasses: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    className: ['custom-breadcrumb', 'additional-class']
+  }
+};
+
+export const CustomStyles: Story = {
+  args: {
+    items: [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    style: {
+      fontSize: '18px',
+      padding: '16px',
+      backgroundColor: '#6c3f3f'
+    }
+  }
+};
+
+export const CustomTestId: Story = {
+  args: {
+    'items': [
+      { label: 'Home', link: '/' },
+      { label: 'Products', link: '/products' },
+      { label: 'Current Page' }
+    ],
+    'data-testid': 'custom-breadcrumbs-id'
+  }
+};
+
+export const SingleItem: Story = {
+  args: {
+    items: [
+      { label: 'Current Page' }
+    ]
+  }
+};

--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { Breadcrumbs, type BreadcrumbItem } from './Breadcrumbs';
+import { renderWithProviders } from '../../../../test-setup/renderWithProviders';
+
+// Mock CSS module
+vi.mock('./Breadcrumbs.module.css', () => ({
+  default: {
+    'breadcrumbs': 'breadcrumbs',
+    'variant--truncate': 'variant--truncate',
+    'variant--wrap': 'variant--wrap',
+    'separator': 'separator',
+    'label': 'label'
+  }
+}));
+
+describe('Breadcrumbs', () => {
+  const baseItems: BreadcrumbItem[] = [
+    { label: 'Home', link: '/' },
+    { label: 'Library', link: '/library' },
+    { label: 'Current' }
+  ];
+
+  it('renders with default props and items', () => {
+    renderWithProviders(<Breadcrumbs items={baseItems} />);
+
+    const nav = screen.getByTestId('breadcrumbs');
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveAttribute('aria-label', 'breadcrumbs');
+
+    const list = nav.querySelector('ol');
+    expect(list).toBeInTheDocument();
+
+    const items = list!.querySelectorAll('li');
+    expect(items.length).toBe(3);
+
+    // First item has no separator
+    expect(items[0].querySelector(`.${'separator'}`)).toBeNull();
+
+    // Subsequent items have separator
+    expect(items[1].querySelector(`.${'separator'}`)).toHaveTextContent('/');
+    expect(items[2].querySelector(`.${'separator'}`)).toHaveTextContent('/');
+
+    // Last item has aria-current="page"
+    expect(items[2]).toHaveAttribute('aria-current', 'page');
+    expect(items[0].getAttribute('aria-current')).toBeNull();
+  });
+
+  it('uses custom data-testid when provided', () => {
+    renderWithProviders(<Breadcrumbs items={baseItems} data-testid="custom-breadcrumbs" />);
+    expect(screen.getByTestId('custom-breadcrumbs')).toBeInTheDocument();
+  });
+
+  it('applies variant class names - truncate', () => {
+    renderWithProviders(
+      <Breadcrumbs items={baseItems} variant="truncate" />
+    );
+    const list = screen.getByRole('navigation').querySelector('ol')!;
+    expect(list.className).toContain('breadcrumbs');
+    expect(list.className).toContain('variant--truncate');
+  });
+
+  it('applies variant class names - wrap', () => {
+    renderWithProviders(
+      <Breadcrumbs items={baseItems} variant="wrap" />
+    );
+
+    const list2 = screen.getByRole('navigation').querySelector('ol')!;
+    expect(list2.className).toContain('variant--wrap');
+  });
+
+  it('applies custom className and style to the list', () => {
+    renderWithProviders(
+      <Breadcrumbs
+        items={baseItems}
+        className={['extra-class']}
+        style={{ marginTop: '10px' }}
+      />
+    );
+
+    const list = screen.getByRole('navigation').querySelector('ol')!;
+    expect(list.className).toContain('extra-class');
+    expect(list).toHaveStyle({ marginTop: '10px' });
+  });
+
+  it('renders links for items with link and text for items without link', () => {
+    renderWithProviders(<Breadcrumbs items={baseItems} />);
+
+    const links0 = screen.getByTestId('breadcrumbs-link-0');
+
+    expect(links0).toHaveAttribute('href', '/');
+    expect(links0).toHaveTextContent('Home');
+
+    const links1 = screen.getByTestId('breadcrumbs-link-1');
+
+    expect(links1).toHaveAttribute('href', '/library');
+    expect(links1).toHaveTextContent('Library');
+
+    const texts0 = screen.getByTestId('breadcrumbs-text');
+
+    expect(texts0).toHaveTextContent('Current');
+  });
+
+  it('uses provided separator', () => {
+    renderWithProviders(<Breadcrumbs items={baseItems} separator=">" />);
+
+    const separators = screen
+      .getByRole('navigation')
+      .querySelectorAll(`.${'separator'}`);
+    expect(separators.length).toBe(2);
+    separators.forEach((sep) => {
+      expect(sep).toHaveTextContent('>');
+      expect(sep).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('handles single item without separators', () => {
+    renderWithProviders(<Breadcrumbs items={[{ label: 'Only' }]} />);
+
+    const items = screen
+      .getByRole('navigation')
+      .querySelectorAll('li');
+    expect(items.length).toBe(1);
+
+    expect(items[0]).toHaveAttribute('aria-current', 'page');
+    expect(items[0].querySelector(`.${'separator'}`)).toBeNull();
+  });
+});

--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { TextMedium } from '../Text/Text.tsx';
+import { Link } from '../Link/Link.tsx';
+
+import styles from './Breadcrumbs.module.css';
+import { cx } from '../../../../utils';
+
+export interface BreadcrumbItem {
+  label: string
+  link?: string
+}
+
+export interface BreadcrumbsProps {
+  className?: string[]
+  style?: React.CSSProperties
+  ['data-testid']?: string
+  items: BreadcrumbItem[]
+  variant?: 'truncate' | 'wrap'
+  separator?: string
+}
+
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+  className,
+  style,
+  items,
+  variant = 'truncate',
+  separator = '/',
+  'data-testid': dataTestId = 'breadcrumbs'
+}) => {
+  const classes = cx(
+    styles.breadcrumbs,
+    styles[`variant--${variant}`],
+    ...(className || [])
+  );
+
+  return (
+    <nav data-testid={dataTestId} aria-label="breadcrumbs">
+      <ol style={style} className={classes}>
+        {
+          items.map((item, i) => (
+            <li key={item.label} aria-current={i === items.length - 1 ? 'page' : undefined}>
+              {i > 0
+                ? (
+                  <span className={styles.separator} aria-hidden="true">{separator}</span>
+                )
+                : undefined}
+              {
+                item.link
+                  ? (
+                    <Link to={item.link} className={[styles.label]} data-testid={`${dataTestId}-link-${i}`}>{item.label}</Link>
+                  )
+                  : (
+                    <TextMedium className={[styles.label]} data-testid={`${dataTestId}-text`}>{item.label}</TextMedium>
+                  )
+              }
+            </li>
+          ))
+        }
+      </ol>
+    </nav>
+  );
+};

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -17,6 +17,9 @@
   --font-weight-light: 300;
 
   --container-padding: 1rem;
+
+  --breadcrumbs-gap: 0.25rem;
+  
   font-family: "Inter", sans-serif;
   font-optical-sizing: auto;
   font-style: normal;


### PR DESCRIPTION
## 📦 What’s inside this PR?

- Breadcrumbs component was added
- **supports**: 
  - `style`: React.CSSProperties,
  - `className`: string[], 
  - `['data-testid']`: string
  - `links`: BreadcrumbItem[]
  - `behaviour`: 'truncate' | 'wrap'
  - `separator`: string
  
 **Attention**
 According to the The a11y [Breadcrumbs Pattern example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/) and [Breadcrumbs Pattern About](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) current page element (at Breadcrumbs component it is last one) must to have the [arria-current](https://w3c.github.io/aria/#aria-current) attribute. 
 
 Current way to implement the Breadcrumbs not fully follows to the Breadcrumbs Pattern.  w3.org offer to use as last item anchor element with empty `href=''` value. 
 ```html
 <li>
  <a href="" aria-current="page">Breadcrumb Example</a>
</li>
```

The [article](https://tink.uk/using-the-aria-current-attribute/) not recomend to use anchors with empty `href=""`.

The [digitala11y](https://www.digitala11y.com/aria-current-state/#screen-reader-support) provide the tables of screenreaders with aria-current comptability. So topic has a reasons to implement in the right way.

I guess the last item of Breadcrumbs component must be 
 ```html
 <li>
  <a href="**curent page link**" aria-current="page">Breadcrumb Example</a>
</li>
```

@leva13007  the final decision on you.

<img width="878" height="451" alt="image" src="https://github.com/user-attachments/assets/a1e5e4df-6f0f-4864-8fa0-c7607f3489f4" />


---

## 📄 Related Issue

Closes [MC-4](https://zloyleva.atlassian.net/jira/software/projects/MC/boards/34?selectedIssue=MC-4)  


---

## ✅ Checklist (before submitting)

- [x] The PR targets the `develop` branch
- [x] I've followed the [Git Flow rules](../docs/git-flow.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code builds and works locally (`pnpm dev`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] I've updated documentation if needed

---

[MC-4]: https://zloyleva.atlassian.net/browse/MC-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ