### PR TITLE
chore(MC-17) Implement using classes by components

### DIFF
--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.tsx
@@ -3,7 +3,7 @@ import { TextMedium } from '../Text/Text.tsx';
 import { TextLink } from '../TextLink/TextLink.tsx';
 
 import styles from './Breadcrumbs.module.css';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 export interface BreadcrumbItem {
   label: string
@@ -27,9 +27,10 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   separator = '/',
   'data-testid': dataTestId = 'breadcrumbs'
 }) => {
-  const classes = cx(
-    styles.breadcrumbs,
-    styles[`variant--${variant}`],
+  const classes = clx(
+    styles,
+    'breadcrumbs',
+    `variant--${variant}`,
     ...(className || [])
   );
 

--- a/src/shared/ui/atoms/Container/Container.tsx
+++ b/src/shared/ui/atoms/Container/Container.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './Container.module.css';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 interface ContainerProps {
   children: React.ReactNode
@@ -10,10 +10,11 @@ interface ContainerProps {
 }
 
 export const Container: React.FC<ContainerProps> = ({ children, className, style, fluid }) => {
-  const classes = cx(
-    styles.container,
+  const classes = clx(
+    styles,
+    'container',
     ...(className || []),
-    fluid ? styles['container-fluid'] : undefined
+    fluid ? 'container-fluid' : undefined
   );
 
   return (

--- a/src/shared/ui/atoms/H1/H1.tsx
+++ b/src/shared/ui/atoms/H1/H1.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './H1.module.css';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 interface H1Props {
   children: React.ReactNode
@@ -10,8 +10,9 @@ interface H1Props {
 }
 
 export const H1: React.FC<H1Props> = ({ children, className, style, 'data-testid': dataTestId = 'heading' }) => {
-  const classes = cx(
-    styles.h1,
+  const classes = clx(
+    styles,
+    'h1',
     ...(className || [])
   );
 

--- a/src/shared/ui/atoms/H2/H2.tsx
+++ b/src/shared/ui/atoms/H2/H2.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './H2.module.css';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 interface H1Props {
   children: React.ReactNode
@@ -10,8 +10,9 @@ interface H1Props {
 }
 
 export const H2: React.FC<H1Props> = ({ children, className, style, 'data-testid': dataTestId = 'heading-2' }) => {
-  const classes = cx(
-    styles.h2,
+  const classes = clx(
+    styles,
+    'h2',
     ...(className || [])
   );
 

--- a/src/shared/ui/atoms/Text/Text.tsx
+++ b/src/shared/ui/atoms/Text/Text.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './Text.module.css';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 export interface TextProps {
   children: React.ReactNode
@@ -16,10 +16,11 @@ type CssVariantKey = 'text-medium' | 'text-light' | 'text-bold';
 const TextBase: React.FC<TextProps & { cssVariantKey: CssVariantKey }> = ({ children, className, style, variant, as, 'data-testid': dataTestId = 'text-base', cssVariantKey }) => {
   const As = as || 'span';
 
-  const classes = cx(
-    styles.text,
+  const classes = clx(
+    styles,
+    'text',
     styles[cssVariantKey],
-    variant === 'warning' ? styles.warning : styles.primary,
+    variant === 'warning' ? 'warning' : 'primary',
     ...(className || [])
   );
 

--- a/src/shared/ui/atoms/TextLink/TextLink.stories.tsx
+++ b/src/shared/ui/atoms/TextLink/TextLink.stories.tsx
@@ -26,6 +26,14 @@ export const Default: Story = {
   }
 };
 
+export const LinkHovered: Story = {
+  args: {
+    content: 'Hovered Link',
+    to: '/',
+    className: ['__hovered', 'additional-class']
+  }
+};
+
 export const RedTitle: Story = {
   args: {
     content: 'Red TextLink',

--- a/src/shared/ui/atoms/TextLink/TextLink.tsx
+++ b/src/shared/ui/atoms/TextLink/TextLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './TextLink.module.css';
 import { Link as RouterLink } from 'react-router';
-import { cx } from '../../../../utils';
+import { clx } from '../../../../utils';
 
 interface TextLinkProps {
   content: string
@@ -20,8 +20,9 @@ export const TextLink: React.FC<TextLinkProps> = ({
   'aria-label': ariaLabel,
   'data-testid': dataTestId = 'link'
 }) => {
-  const classes = cx(
-    styles.link,
+  const classes = clx(
+    styles,
+    'link',
     ...(className || [])
   );
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,58 +1,78 @@
 import { describe, it, expect } from 'vitest';
-import { cx } from './index';
+import { clx } from './index';
 
-describe('cx', () => {
-  it('returns empty string when no arguments are provided', () => {
-    expect(cx()).toBe('');
+describe('clx', () => {
+  const cssModule = {
+    'a': 'hashed_a',
+    'b': 'hashed_b',
+    'with-dash': 'hashed_with_dash'
+  };
+
+  it('returns empty string when no classes are provided', () => {
+    expect(clx(cssModule)).toBe('');
   });
 
-  it('joins multiple string class names with a space', () => {
-    expect(cx('a', 'b', 'c')).toBe('a b c');
+  it('maps known keys from css module and keeps unknown as-is', () => {
+    expect(clx(cssModule, 'a', 'b', 'c')).toBe('hashed_a hashed_b c');
   });
 
-  it('filters out falsy values (undefined, null, false, empty string)', () => {
-    // Note: empty string is falsy and should be filtered as well
-    expect(cx('a', undefined, null, false, '', 'b')).toBe('a b');
+  it('filters out falsy values', () => {
+    expect(clx(cssModule, 'a', undefined, null, false, '', 'b')).toBe(
+      'hashed_a hashed_b'
+    );
   });
 
-  it('handles a single valid class name', () => {
-    expect(cx('only-one')).toBe('only-one');
+  it('handles a single valid class', () => {
+    expect(clx(cssModule, 'a')).toBe('hashed_a');
   });
 
   it('handles only falsy values', () => {
-    expect(cx(undefined, null, false, '')).toBe('');
+    expect(clx(cssModule, undefined, null, false, '')).toBe('');
   });
 
-  it('handles duplicate class names', () => {
-    expect(cx('a', 'a', 'b')).toBe('a a b');
+  it('handles duplicate class names (after mapping)', () => {
+    expect(clx(cssModule, 'a', 'a', 'b')).toBe('hashed_a hashed_a hashed_b');
   });
 
-  it('flattens a simple nested array of class names', () => {
-    expect(cx(['a', 'b'] as unknown as never)).toBe('a b');
+  it('falls back to raw class if not present in css module', () => {
+    expect(clx(cssModule, 'unknown', 'a')).toBe('unknown hashed_a');
   });
 
-  it('flattens deeply nested arrays of class names', () => {
+  it('handles keys that include dashes', () => {
+    expect(clx(cssModule, 'with-dash')).toBe('hashed_with_dash');
+  });
+
+  it('flattens nested arrays of classes', () => {
     const nested = ['a', ['b', ['c', 'd']]] as unknown as never;
-    expect(cx(nested)).toBe('a b c d');
+    expect(clx(cssModule, 'hashed_a', 'hashed_b', nested)).toBe('hashed_a hashed_b hashed_a hashed_b c d');
   });
 
   it('filters falsy values inside nested arrays', () => {
     const nested = ['a', [undefined, null, false, '', 'b']] as unknown as never;
-    expect(cx(nested)).toBe('a b');
+    expect(clx(cssModule, nested)).toBe('hashed_a hashed_b');
   });
 
-  it('handles mix of top-level and nested array class names', () => {
+  it('handles mix of top-level and nested class names', () => {
     const nested = ['a', ['b', 'c']] as unknown as never;
-    expect(cx('start', nested, 'end' as unknown as never)).toBe('start a b c end');
+    expect(clx(cssModule, 'start', nested, 'end' as unknown as never)).toBe(
+      'start hashed_a hashed_b c end'
+    );
   });
 
   it('returns empty string for nested arrays with only falsy values', () => {
     const nested = [[undefined, null], [false, '']] as unknown as never;
-    expect(cx(nested)).toBe('');
+    expect(clx(cssModule, nested)).toBe('');
   });
 
   it('preserves order with nested arrays and duplicates', () => {
     const nested = ['a', ['b', 'a', 'c']] as unknown as never;
-    expect(cx('x', nested, 'y' as unknown as never)).toBe('x a b a c y');
+    expect(clx(cssModule, 'x', nested, 'y' as unknown as never)).toBe(
+      'x hashed_a hashed_b hashed_a c y'
+    );
+  });
+
+  it('ignores extra keys not used in arguments', () => {
+    const bigCssModule = { ...cssModule, extra: 'extra_hashed' };
+    expect(clx(bigCssModule, 'a')).toBe('hashed_a');
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
-export const cx = (...classNames: (string | undefined | false | null)[]): string => {
-  return classNames.flat(Infinity).filter(Boolean).join(' ');
+export const clx = (cssModuleObject: Record<string, string>, ...cls: (string | undefined | false | null)[]): string => {
+  const incomingClasses = ((cls || []).flat(Infinity).filter(Boolean) as string[]).map(cl => cssModuleObject[cl] ?? cl);
+  return incomingClasses.join(' ');
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,12 @@ export default mergeConfig(
             name: 'react',
             globals: true,
             environment: 'jsdom',
-            setupFiles: ['./src/test-setup/vitest.setup.ts']
+            setupFiles: ['./src/test-setup/vitest.setup.ts'],
+            css: {
+              modules: {
+                classNameStrategy: 'non-scoped'
+              }
+            }
           }
         }),
         defineProject({


### PR DESCRIPTION
## 📦 What’s inside this PR?

This PR refactors the utility function for combining CSS class names from cx to clx, introducing integration with CSS modules. The new clx function accepts a CSS module object as its first parameter and maps class name keys to their hashed values, while preserving unknown class names as-is. The vitest configuration has been updated to use non-scoped class names during testing.

Key changes:

- Replaced cx() with clx() utility that maps CSS module class names
- Updated vitest config to use 'non-scoped' CSS modules strategy for tests
- Migrated 6 UI components (H1, H2, Text, TextLink, Container, Breadcrumbs) to use the new utility

---

## 📄 Related Issue

Closes #___  
Related to #___

---

## ✅ Checklist (before submitting)

- [x] The PR targets the `develop` branch
- [x] I've followed the [Git Flow rules](../docs/git-flow.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code builds and works locally (`pnpm dev`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] I've updated documentation if needed

---

## Screenshots

<!-- Screenshots? -->

## 📝 Additional Notes

<!-- Anything else reviewers should know? Gotchas? -->