### PR TITLE
fix(MC-87) Fix passing data-testid to the Storybook

### DIFF
--- a/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/shared/ui/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -13,11 +13,14 @@ const meta = {
     ]
   },
   argTypes: {
-    items: {
+    'items': {
       control: { type: 'object' }
     },
-    separator: {
+    'separator': {
       control: { type: 'text' }
+    },
+    'data-testid': {
+      type: 'string'
     }
   }
 } satisfies Meta<typeof Breadcrumbs>;

--- a/src/shared/ui/atoms/Text/TextBold.stories.tsx
+++ b/src/shared/ui/atoms/Text/TextBold.stories.tsx
@@ -9,8 +9,15 @@ const meta = {
     children: 'Title'
   },
   argTypes: {
-    children: {
+    'children': {
       control: { type: 'text' }
+    },
+    'data-testid': {
+      type: 'string'
+    },
+    'as': {
+      control: { type: 'select' },
+      options: ['span', 'p']
     }
   }
 } satisfies Meta<typeof TextBold>;

--- a/src/shared/ui/atoms/Text/TextLight.stories.tsx
+++ b/src/shared/ui/atoms/Text/TextLight.stories.tsx
@@ -9,8 +9,15 @@ const meta = {
     children: 'Title'
   },
   argTypes: {
-    children: {
+    'children': {
       control: { type: 'text' }
+    },
+    'data-testid': {
+      type: 'string'
+    },
+    'as': {
+      control: { type: 'select' },
+      options: ['span', 'p']
     }
   }
 } satisfies Meta<typeof TextLight>;

--- a/src/shared/ui/atoms/Text/TextMedium.stories.tsx
+++ b/src/shared/ui/atoms/Text/TextMedium.stories.tsx
@@ -9,8 +9,15 @@ const meta = {
     children: 'Title'
   },
   argTypes: {
-    children: {
+    'children': {
       control: { type: 'text' }
+    },
+    'data-testid': {
+      type: 'string'
+    },
+    'as': {
+      control: { type: 'select' },
+      options: ['span', 'p']
     }
   }
 } satisfies Meta<typeof TextMedium>;

--- a/src/shared/ui/atoms/TextLink/TextLink.stories.tsx
+++ b/src/shared/ui/atoms/TextLink/TextLink.stories.tsx
@@ -11,11 +11,14 @@ const meta = {
     to: '/'
   },
   argTypes: {
-    content: {
+    'content': {
       control: { type: 'text' }
     },
-    to: {
+    'to': {
       control: { type: 'text' }
+    },
+    'data-testid': {
+      type: 'string'
     }
   }
 } satisfies Meta<typeof TextLink>;


### PR DESCRIPTION
## 📦 What’s inside this PR?

<!-- Describe your change in one or two sentences -->

- Add argTypes['data-testid'] to multiple Atom/Molecule stories.
- Add an as select control to Text* stories.
- Normalize some argTypes keys to quoted property names.

---

## 📄 Related Issue

Closes #___  
Related to #___

---

## ✅ Checklist (before submitting)

- [x] The PR targets the `develop` branch
- [x] I've followed the [Git Flow rules](../docs/git-flow.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code builds and works locally (`pnpm dev`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] I've updated documentation if needed

---

## Screenshots

<!-- Screenshots? -->

## 📝 Additional Notes

<!-- Anything else reviewers should know? Gotchas? -->